### PR TITLE
Optimize CI/CD workflows to skip non-code changes

### DIFF
--- a/.github/workflows/codesee-arch-diagram.yml
+++ b/.github/workflows/codesee-arch-diagram.yml
@@ -2,8 +2,18 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - 'internaldocs/**'
+      - '**/*.md'
+      - '**/*.txt'
+      - '.github/**'
   pull_request_target:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - 'internaldocs/**'
+      - '**/*.md'
+      - '**/*.txt'
+      - '.github/**'
 
 name: CodeSee Map
 

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,7 @@
   "framework": "angular",
   "buildCommand": "yarn build",
   "outputDirectory": "dist/Patcher/browser",
+  "ignoreCommand": "git diff HEAD^ HEAD --name-only | grep -qvE '^(internaldocs/|[^/]+\\.md$|[^/]+\\.txt$|\\.github/)'",
   "rewrites": [
     {
       "source": "/sitemap.xml",


### PR DESCRIPTION
## Summary
This PR optimizes CI/CD pipeline efficiency by configuring both the CodeSee architecture diagram workflow and Vercel deployment to skip unnecessary builds when only documentation, configuration, or internal files are modified.

## Key Changes
- **CodeSee Workflow**: Added `paths-ignore` filters to both `push` (master branch) and `pull_request_target` triggers to skip the CodeSee Map generation when changes are limited to:
  - Internal documentation (`internaldocs/**`)
  - Markdown files (`**/*.md`)
  - Text files (`**/*.txt`)
  - GitHub configuration (`.github/**`)

- **Vercel Deployment**: Added `ignoreCommand` configuration to prevent unnecessary Vercel builds when only non-code files are changed, using the same file patterns as the CodeSee workflow

## Benefits
- Reduces unnecessary workflow executions and CI/CD resource consumption
- Prevents redundant Vercel deployments for documentation-only changes
- Maintains consistency between workflow triggers and deployment logic
- Improves overall development velocity by avoiding false-positive builds

https://claude.ai/code/session_01GhmzRnzXzPRPZCvBFQnuCw